### PR TITLE
Add changes to support netstandard2.0 in core library

### DIFF
--- a/Interpose.Core.Tests/Interpose.Core.Tests.csproj
+++ b/Interpose.Core.Tests/Interpose.Core.Tests.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <StartupObject>Interpose.Core.Tests.Program</StartupObject>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
@@ -15,9 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Interpose.Core\Interpose.Core.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Interpose.Core/Generators/CachedTypeGenerator.cs
+++ b/Interpose.Core/Generators/CachedTypeGenerator.cs
@@ -19,11 +19,10 @@ namespace Interpose.Core.Generators
         {
             var type = this.Lookup(interceptor, baseType, additionalInterfaceTypes, handlerType);
 
-            if (type == null)
-            {
-                type = this.generator.Generate(interceptor, baseType, handlerType, additionalInterfaceTypes);
-                this.Register(interceptor, type, baseType, additionalInterfaceTypes, handlerType);
-            }
+            if (type != null) return type;
+            
+            type = this.generator.Generate(interceptor, baseType, handlerType, additionalInterfaceTypes);
+            this.Register(interceptor, type, baseType, additionalInterfaceTypes, handlerType);
 
             return type;
         }
@@ -35,9 +34,9 @@ namespace Interpose.Core.Generators
             this.proxyTypes[key] = type;
         }
 
-        private string GenerateKey(Type baseType, Type[] additionalInterfaceTypes, Type handlerType)
+        private string GenerateKey(Type baseType, IEnumerable<Type> additionalInterfaceTypes, Type handlerType)
         {
-            var key = string.Join(';', new[] { baseType }.Concat(additionalInterfaceTypes).Concat(new[] { handlerType }).Select(x => x.FullName));
+            var key = string.Join(";", new[] { baseType }.Concat(additionalInterfaceTypes).Concat(new[] { handlerType }).Select(x => x.FullName));
 
             return key;
         }

--- a/Interpose.Core/Generators/RoslynInterceptedTypeGenerator.cs
+++ b/Interpose.Core/Generators/RoslynInterceptedTypeGenerator.cs
@@ -164,6 +164,7 @@ namespace Interpose.Core.Generators
                 MetadataReference.CreateFromFile(typeof(Lazy<,>).Assembly.Location),      //System.Runtime
                 MetadataReference.CreateFromFile(typeof(Object).Assembly.Location),       //System.Private.CoreLib
                 MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),      //System.Console
+                MetadataReference.CreateFromFile(Assembly.Load("netstandard, Version=2.0.0.0").Location)
             };
 
             if (handlerType != null)

--- a/Interpose.Core/Interpose.Core.csproj
+++ b/Interpose.Core/Interpose.Core.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Interpose.Core</AssemblyName>
     <RootNamespace>Interpose.Core</RootNamespace>
     <PackageId>Interpose.Core</PackageId>
@@ -12,7 +11,8 @@
     <Copyright>Copyright © Ricardo Peres 2018</Copyright>
     <PackageLicenseUrl>https://github.com/rjperes/Interpose.Core/blob/master/lgpl.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/rjperes/Interpose.Core</PackageProjectUrl>
-    <PackageIconUrl></PackageIconUrl>
+    <PackageIconUrl>
+    </PackageIconUrl>
     <RepositoryUrl>https://github.com/rjperes/Interpose.Core</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <NeutralLanguage>en</NeutralLanguage>
@@ -20,14 +20,13 @@
     <PackageTags>netcore,aop,interception</PackageTags>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="System.CodeDom" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.DispatchProxy" Version="4.4.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
I can't see a reason why this library cannot support NetStandard 2.0, and thereby allowing it to be run on a wider number of platforms (NetFramework, Xamarin, UWP, etc).

Note: The broken unit test is still broken.